### PR TITLE
Outlook integration package signing and uploading

### DIFF
--- a/pages/gmail/index.tsx
+++ b/pages/gmail/index.tsx
@@ -11,6 +11,7 @@ import noop from 'lodash/noop'
 
 import { handleGoToApp } from '../../utils'
 import { publicRuntimeConfig } from '../../utils/config'
+import objToFile from '../../utils/objToFile'
 import { GoogleLogin, Header, Loading, Overlay, Progress } from '../../utils/styles'
 import { formatTimeLeft } from '../../utils/time'
 import api from '../../utils/api'
@@ -217,9 +218,8 @@ class App extends PureComponent<Props, State> {
     const { googleAuth } = this.state
 
     this.setState({ step: STEPS.signingFile })
-    const blob = new Blob([JSON.stringify(this.messages)])
 
-    const file = new File([blob], 'data.json', { type: 'application/json' })
+    const file = objToFile(this.messages)
 
     const s3Data = await api.signGmailPackage({
       name: file.name,
@@ -240,7 +240,7 @@ class App extends PureComponent<Props, State> {
       })
 
       this.setState({ step: STEPS.notifyApp })
-      await api.sendNotification(s3Id, get(googleAuth, 'email') || '')
+      await api.sendGmailNotification(s3Id, get(googleAuth, 'email') || '')
     }
 
     this.handleLogout(true)()

--- a/pages/microsoft-outlook/index.tsx
+++ b/pages/microsoft-outlook/index.tsx
@@ -22,6 +22,9 @@ function isFetchingStage(fetchingStage: FetchingStage) {
   return includes([
     FetchingStage.authorizing,
     FetchingStage.fetchingMessages,
+    FetchingStage.signingFile,
+    FetchingStage.uploadingFile,
+    FetchingStage.notifyApp,
   ], fetchingStage)
 }
 
@@ -48,7 +51,7 @@ export default function MicrosoftTeamsPage(props: Props) {
   const isDone = state.fetchingStage === FetchingStage.done
 
   if (isDone) {
-    return <Done infoText="From/To/Cc/Bcc" />
+    return <Done infoText="From/To/Cc" />
   }
 
   const isFetching = isFetchingStage(state.fetchingStage)
@@ -60,6 +63,9 @@ export default function MicrosoftTeamsPage(props: Props) {
           <Image alt="loader" mb={4} src="/static/loader.svg" />
           {state.fetchingStage === FetchingStage.authorizing ? 'Waiting for authorization...' : null}
           {state.fetchingStage === FetchingStage.fetchingMessages ? `Loading ${state.messagesCount} messages...` : null}
+          {state.fetchingStage === FetchingStage.signingFile ? `Signing metadata file to upload...` : null}
+          {state.fetchingStage === FetchingStage.uploadingFile ? `Uploading metadata file...` : null}
+          {state.fetchingStage === FetchingStage.notifyApp ? `Notify application about upload...` : null}
         </Loading>
       </Overlay>
     );
@@ -84,7 +90,7 @@ export default function MicrosoftTeamsPage(props: Props) {
               To
             </Text>
             <Text color="#364152" fontSize={['10px', '12px']}>
-              Cc/Bcc
+              Cc
             </Text>
           </Flex>
           <Box bg="#e3e3e6" height="1px" width="100%" />

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -65,9 +65,29 @@ async function getMyEmails(): Promise<boolean | string[]> {
   }
 }
 
-async function sendNotification(id: string, email: string): Promise<boolean> {
+async function sendGmailNotification(
+  id: string,
+  email: string,
+): Promise<boolean> {
   const response = await axiosWithRefresh.get(
     `${publicRuntimeConfig.API_HOST}/private/gmailPackageUploaded`,
+    {
+      headers: getAuthHeaders(),
+      params: { id, email },
+    },
+  )
+
+  const data = get(response, 'data', { ok: false })
+
+  return data.ok
+}
+
+async function sendOutlookNotification(
+  id: string,
+  email: string,
+): Promise<boolean> {
+  const response = await axiosWithRefresh.get(
+    `${publicRuntimeConfig.API_HOST}/private/outlookPackageUploaded`,
     {
       headers: getAuthHeaders(),
       params: { id, email },
@@ -110,9 +130,42 @@ async function signGmailPackage({
   return false
 }
 
+async function signOutlookPackage({
+  name,
+  contentType,
+  size,
+  email,
+}: {
+  name: string
+  contentType: string
+  size: number
+  email: string
+}): Promise<{ id: string; s3Url: string } | boolean> {
+  const response = await axiosWithRefresh.get(
+    `${publicRuntimeConfig.API_HOST}/private/signOutlookPackage`,
+    {
+      headers: getAuthHeaders(),
+      params: { name, contentType, size, email },
+    },
+  )
+
+  const data = get(response, 'data', { ok: false })
+
+  if (data.ok) {
+    return {
+      id: data.id,
+      s3Url: data.s3Url,
+    }
+  }
+
+  return false
+}
+
 export default {
   checkAuthorized,
   signGmailPackage,
-  sendNotification,
+  signOutlookPackage,
+  sendGmailNotification,
+  sendOutlookNotification,
   getMyEmails,
 }

--- a/utils/microsoft-outlook/actions/fetchMessages.ts
+++ b/utils/microsoft-outlook/actions/fetchMessages.ts
@@ -21,6 +21,7 @@ import { actionTypes, Action } from '../reducer'
 
 const mapMessage = (message: any) => ({
   id: get(message, 'id'),
+  threadId: get(message, 'conversationId'),
   date: get(message, 'createdDateTime'),
   from: [get(message, 'from.emailAddress')],
   to: map(get(message, 'toRecipients'), 'emailAddress'),
@@ -34,7 +35,13 @@ async function* messagesIterator(accessToken: string) {
     // eslint-disable-next-line no-await-in-loop
     const messages = await fetchMSGraph(url, {
       accessToken,
-      select: ['from', 'toRecipients', 'ccRecipients', 'createdDateTime'],
+      select: [
+        'from',
+        'toRecipients',
+        'ccRecipients',
+        'createdDateTime',
+        'conversationId',
+      ],
     })
     if (!messages || isEmpty(messages.value)) {
       return

--- a/utils/microsoft-outlook/reducer.ts
+++ b/utils/microsoft-outlook/reducer.ts
@@ -10,6 +10,9 @@ export const actionTypes = {
   FETCH_SUCCESS: 'FETCH_SUCCESS',
   MESSAGES_FETCH_START: 'MESSAGES_FETCH_START',
   NEW_MESSAGES: 'NEW_MESSAGES',
+  NOTIFICATION_START: 'NOTIFICATION_START',
+  SIGN_FILE_START: 'SIGN_FILE_START',
+  UPLOAD_FILE_START: 'UPLOAD_FILE_START',
   WRONG_EMAIL: 'WRONG_EMAIL',
 }
 
@@ -17,6 +20,9 @@ export enum FetchingStage {
   notStarted = 'notStarted',
   authorizing = 'authorizing',
   fetchingMessages = 'fetchingMessages',
+  signingFile = 'signingFile',
+  uploadingFile = 'uploadingFile',
+  notifyApp = 'notifyApp',
   done = 'done',
   error = 'error',
 }
@@ -66,6 +72,24 @@ export function reducer(state: State, action: Action): State {
     return {
       ...state,
       messagesCount: state.messagesCount + action.payload,
+    }
+  }
+  if (action.type === actionTypes.NOTIFICATION_START) {
+    return {
+      ...state,
+      fetchingStage: FetchingStage.notifyApp,
+    }
+  }
+  if (action.type === actionTypes.SIGN_FILE_START) {
+    return {
+      ...state,
+      fetchingStage: FetchingStage.signingFile,
+    }
+  }
+  if (action.type === actionTypes.UPLOAD_FILE_START) {
+    return {
+      ...state,
+      fetchingStage: FetchingStage.uploadingFile,
     }
   }
   if (action.type === actionTypes.WRONG_EMAIL) {

--- a/utils/objToFile.ts
+++ b/utils/objToFile.ts
@@ -1,0 +1,9 @@
+export default function objToFile(obj: object, possiblyFilename?: string) {
+  const filename = possiblyFilename || 'data.json'
+
+  const blob = new Blob([JSON.stringify(obj)])
+
+  const file = new File([blob], filename, { type: 'application/json' })
+
+  return file
+}


### PR DESCRIPTION
# Changelog

- Split `sendNotification` into `sendGmailNotification` and `sendOutlookNotification`.
- Migrate `microsoft-outlook` upload file messages to match `gmail` structure.
- Add sign upload and notification steps for Microsoft Outlook integration.
- Add `objToFile` utility.

[Synchronos Link](https://synchronos.io/app/projects/4c4a604a-813c-480a-bcea-d0172f0d2ab4/tasks/7414f708-aa3d-4ef5-be8f-b8c3cf90120b)